### PR TITLE
Fixed links to the haar cascades and shape detector files in pnp headpose estimation examples

### DIFF
--- a/examples/ex_pnp_head_pose_estimation_video.py
+++ b/examples/ex_pnp_head_pose_estimation_video.py
@@ -138,8 +138,8 @@ def main():
                                   P3D_STOMION])
 
     #Declaring the two classifiers
-    my_cascade = haarCascade("./etc/haarcascade_frontalface_alt.xml", "./etc/haarcascade_profileface.xml")
-    my_detector = faceLandmarkDetection('./etc/shape_predictor_68_face_landmarks.dat')
+    my_cascade = haarCascade("../etc/xml/haarcascade_frontalface_alt.xml", "../etc/xml/haarcascade_profileface.xml")
+    my_detector = faceLandmarkDetection('../etc/shape_predictor_68_face_landmarks.dat')
 
     #Error counter definition
     no_face_counter = 0

--- a/examples/ex_pnp_head_pose_estimation_webcam.py
+++ b/examples/ex_pnp_head_pose_estimation_webcam.py
@@ -121,9 +121,9 @@ def main():
                                   P3D_STOMION])
 
     #Declaring the two classifiers
-    my_cascade = haarCascade("./etc/xml/haarcascade_frontalface_alt.xml", "./etc/xml/haarcascade_profileface.xml")
+    my_cascade = haarCascade("../etc/xml/haarcascade_frontalface_alt.xml", "../etc/xml/haarcascade_profileface.xml")
     #TODO If missing, example file can be retrieved from http://dlib.net/files/shape_predictor_68_face_landmarks.dat.bz2
-    my_detector = faceLandmarkDetection('./etc/shape_predictor_68_face_landmarks.dat')
+    my_detector = faceLandmarkDetection('../etc/shape_predictor_68_face_landmarks.dat')
 
     #Error counter definition
     no_face_counter = 0


### PR DESCRIPTION
The reference to the haarcascade xmls and the face landmark detector files were incorrect.