### PR TITLE
Load Models on Request 

### DIFF
--- a/deepgaze/load_model.py
+++ b/deepgaze/load_model.py
@@ -59,7 +59,7 @@ class LoadModel:
         cwd = os.getcwd()
 
         # Check if given model is already downloaded
-        if self.check_exists(name) is False:
+        if self.checkExists(name) is False:
 
             zip_file_url = self.models[name]["Link"]
 
@@ -78,5 +78,7 @@ class LoadModel:
         else:
 
             return_path = cwd + "/" + name
+            
+        print("DONE")
 
         return return_path

--- a/deepgaze/load_model.py
+++ b/deepgaze/load_model.py
@@ -35,10 +35,10 @@ class LoadModel:
            args:
                
                name: Name of given model"""
-        
-        #Get current directory
+
+        # Get current directory
         cwd = os.getcwd()
-        return os.path.isdir(cwd +"/"+name)
+        return os.path.isdir(cwd + "/" + name)
 
     def getModel(self, name, params=""):
         """Get the file/path of the required model. If not present, download the required
@@ -54,31 +54,29 @@ class LoadModel:
                return_path: The path of retrieved model
                
         """
-        
-        #Check current directory
+
+        # Check current directory
         cwd = os.getcwd()
-        
+
         # Check if given model is already downloaded
         if self.check_exists(name) is False:
 
             zip_file_url = self.models[name]["Link"]
-            
+
             print("Downloading.... " + name + " model")
             r = requests.get(zip_file_url)
             z = zipfile.ZipFile(io.BytesIO(r.content))
             z.extractall(name)
-            shutil.move(name,cwd)
 
         return_path = ""
 
         # If a given subcategory of model is specified
         if params:
 
-            return_path += cwd +"/"+ name + "/" + self.models[name][params]
+            return_path += cwd + "/" + name + "/" + self.models[name][params]
 
         else:
 
-            return_path = cwd+"/"+ name
+            return_path = cwd + "/" + name
 
         return return_path
-

--- a/deepgaze/load_model.py
+++ b/deepgaze/load_model.py
@@ -1,0 +1,79 @@
+import requests, zipfile, io
+import itertools
+import threading
+import time
+import sys
+import os
+import shutil
+
+
+class Load_Model:
+    """Module that allows users to download and load deepgaze pre-trained models. This allows the required 
+       models to be downloaded on request when required."""
+
+    def __init__(self):
+
+        self.models = {
+            "Head pose estimation": {
+                "Link": "https://www.dropbox.com/s/jnra8jt9ty3qp99/head_pose.zip?dl=1",
+                "roll": "tensorflow/head_pose/roll/cnn_cccdd_30k.tf",
+                "yaw": "tensorflow/head_pose/yaw/cnn_cccdd_30k.tf",
+                "pitch": "tensorflow/head_pose/pitch/cnn_cccdd_30k.tf",
+            },
+            "Haar Cascades": {
+                "Link": "https://dl.dropbox.com/s/1a98kz7yrotbpjz/xml.zip",
+                "profile face": "xml/haarcascade_profileface.xml",
+                "frontal face": "xml/haarcascade_frontalface_alt.xml",
+            },
+        }
+
+        self.abs_path = os.path.relpath("..") + "/models/"
+
+    def check_exists(self, name):
+
+        """Check if a given model exists.
+           args:
+               
+               name: Name of given model"""
+
+        return os.path.isdir(self.abs_path + name)
+
+    def get_model(self, name, params=""):
+        """Get the file/path of the required model. If not present, download the required
+           model.
+           
+           args:
+               
+               name: name of given model.
+               params: if the given subcategory of model is specified
+               
+           returns:
+               
+               return_path: The path of retrieved model
+               
+        """
+
+        # Check if given model is already downloaded
+        if self.check_exists(name) is False:
+
+            zip_file_url = self.models[name]["Link"]
+
+            print("Downloading.... " + name + " model")
+            r = requests.get(zip_file_url)
+            z = zipfile.ZipFile(io.BytesIO(r.content))
+            z.extractall(name)
+            shutil.move(name, self.abs_path)
+
+        return_path = ""
+
+        # If a given subcategory of model is specified
+        if params:
+
+            return_path += self.abs_path + name + "/" + self.models[name][params]
+
+        else:
+
+            return_path = self.abs_path + name
+
+        return return_path
+

--- a/deepgaze/load_model.py
+++ b/deepgaze/load_model.py
@@ -35,8 +35,10 @@ class Load_Model:
            args:
                
                name: Name of given model"""
-
-        return os.path.isdir(self.abs_path + name)
+        
+        #Get current directory
+        cwd = os.getcwd()
+        return os.path.isdir(cwd +"/"+name)
 
     def get_model(self, name, params=""):
         """Get the file/path of the required model. If not present, download the required
@@ -52,28 +54,31 @@ class Load_Model:
                return_path: The path of retrieved model
                
         """
-
+        
+        #Check current directory
+        cwd = os.getcwd()
+        
         # Check if given model is already downloaded
         if self.check_exists(name) is False:
 
             zip_file_url = self.models[name]["Link"]
-
+            
             print("Downloading.... " + name + " model")
             r = requests.get(zip_file_url)
             z = zipfile.ZipFile(io.BytesIO(r.content))
             z.extractall(name)
-            shutil.move(name, self.abs_path)
+            shutil.move(name,cwd)
 
         return_path = ""
 
         # If a given subcategory of model is specified
         if params:
 
-            return_path += self.abs_path + name + "/" + self.models[name][params]
+            return_path += cwd +"/"+ name + "/" + self.models[name][params]
 
         else:
 
-            return_path = self.abs_path + name
+            return_path = cwd+"/"+ name
 
         return return_path
 

--- a/deepgaze/load_model.py
+++ b/deepgaze/load_model.py
@@ -7,7 +7,7 @@ import os
 import shutil
 
 
-class Load_Model:
+class LoadModel:
     """Module that allows users to download and load deepgaze pre-trained models. This allows the required 
        models to be downloaded on request when required."""
 
@@ -29,7 +29,7 @@ class Load_Model:
 
         self.abs_path = os.path.relpath("..") + "/models/"
 
-    def check_exists(self, name):
+    def checkExists(self, name):
 
         """Check if a given model exists.
            args:
@@ -40,7 +40,7 @@ class Load_Model:
         cwd = os.getcwd()
         return os.path.isdir(cwd +"/"+name)
 
-    def get_model(self, name, params=""):
+    def getModel(self, name, params=""):
         """Get the file/path of the required model. If not present, download the required
            model.
            


### PR DESCRIPTION
Currently, the pre-trained models are part of the deepgaze library itself making it heavier than required. This feature allows the users to download required models on the fly. This is a draft pull request for feedback on how to structure it. 

Current output

```
import deepgaze.load_model 

l=load_model.Load_Model()

l.get_model("Haar Cascades")

```

The load model could also load a specific instance of the model, for instance. 

`filepath=l.get_model("Haar Cascades","profile face") `

Downloads the Haar cascades model if not found in the current working directory and then returns the filepath which could be used for usage. 

To Do:
1. Integrate Downloaded models with load models with right file path 
2. Edit tutorials to indicate this feature.  