### PR TITLE
added virtualenv docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ Prerequisites
 
 The current version of Deepgaze is based on **Python 2.7**, a porting for Python 3.0 has been scheduled for the next year.
 
+(Recommended) Create a Python virtual environment:
+You can follow the [Python official documentation](https://docs.python.org/3/tutorial/venv.html) for virtual environments .
+
 To use the libray you have to install:
 
 - Numpy [[link]](http://www.numpy.org/)


### PR DESCRIPTION
While working on Python libraries like computer vision, it is necessary to create a virtual environment because it may sometimes conflict with the default environment, causing libraries to not be installed properly. Creating a virtual environment can provide a separate environment for each project, ensuring that the required libraries and dependencies are isolated and do not interfere with each other. So I had put the official documentation of Python Virtual Environment before the installation command.